### PR TITLE
Endian detection for Apple Silicon

### DIFF
--- a/amiga_hunk_parser.c
+++ b/amiga_hunk_parser.c
@@ -48,7 +48,7 @@
    || defined(_M_ALPHA) || defined(__amd64) \
    || defined(__amd64__) || defined(_M_AMD64) \
    || defined(__x86_64) || defined(__x86_64__) \
-   || defined(_M_X64)
+   || defined(_M_X64) || defined(__arm64__)
 	#define AHP_LITTLE_ENDIAN
 	#define AHP_BYTE_ORDER 1234
 #else


### PR DESCRIPTION
Make the same modification to `amiga_hunk_parser.c` as was made to `endian.h` in https://github.com/emoon/AmigaHunkParser/commit/b94075eea36dd4603454f2c3bb1e9d3cd4eb3e69